### PR TITLE
send `CoinbaseOutputConstraints` based on `PlebLotteryMiningServerConfig.coinbase_output_script`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,6 @@
-use bitcoin::Address;
+use bitcoin::blockdata::locktime::absolute::LockTime;
+use bitcoin::transaction::Version;
+use bitcoin::{Address, Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness};
 use serde::{Deserialize, Deserializer};
 use std::fs;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -22,6 +24,33 @@ pub struct PlebLotteryMiningServerConfig {
     pub coinbase_tag: String,
     pub share_batch_size: usize,
     pub expected_shares_per_minute: f32,
+}
+
+impl PlebLotteryMiningServerConfig {
+    // Returns a tuple with (coinbase_output_max_additional_size, coinbase_output_max_additional_sigops).
+    pub fn calculate_coinbase_output_constraints(&self) -> (u32, u16) {
+        let txout = TxOut {
+            value: Amount::ZERO,
+            script_pubkey: self.coinbase_output_script.clone(),
+        };
+
+        let dummy_transaction = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::from(vec![vec![0; 32]]),
+            }],
+            output: vec![txout.clone()],
+        };
+
+        (
+            txout.size() as u32,
+            dummy_transaction.total_sigop_cost(|_| None) as u16,
+        )
+    }
 }
 
 impl<'de> Deserialize<'de> for PlebLotteryMiningServerConfig {
@@ -72,6 +101,7 @@ impl<'de> Deserialize<'de> for PlebLotteryMiningServerConfig {
 pub struct PlebLotteryTemplateDistributionClientConfig {
     pub server_addr: SocketAddr,
     pub auth_pk: Option<Secp256k1PublicKey>,
+    pub mining_server_config: Option<PlebLotteryMiningServerConfig>,
 }
 
 #[derive(Clone, Deserialize, Debug)]
@@ -90,8 +120,10 @@ impl PleblotteryConfig {
     pub fn from_file<P: AsRef<Path>>(path: P) -> anyhow::Result<Self> {
         let contents = fs::read_to_string(path)
             .map_err(|e| anyhow::anyhow!("Failed to read config file: {}", e))?;
-        let config: Self = toml::from_str(&contents)
+        let mut config: Self = toml::from_str(&contents)
             .map_err(|e| anyhow::anyhow!("Failed to parse config file: {}", e))?;
+        config.template_distribution_config.mining_server_config =
+            Some(config.mining_server_config.clone());
         Ok(config)
     }
 }
@@ -136,7 +168,10 @@ impl From<PlebLotteryTemplateDistributionClientConfig> for Sv2ClientServiceConfi
             template_distribution_config: Some(Sv2ClientServiceTemplateDistributionConfig {
                 server_addr: config.server_addr,
                 auth_pk: config.auth_pk,
-                coinbase_output_constraints: (1, 1), // todo: fix this
+                coinbase_output_constraints: config
+                    .mining_server_config
+                    .unwrap()
+                    .calculate_coinbase_output_constraints(),
                 setup_connection_flags: 0,
             }),
         }
@@ -238,4 +273,34 @@ mod tests {
         let result = std::panic::catch_unwind(|| make_config("this_is_not_a_valid_address"));
         assert!(result.is_err(), "Expected panic for invalid address");
     }
+<<<<<<< Updated upstream
+=======
+
+    #[test]
+    fn test_calculate_coinbase_output_constraints() {
+        // P2PKH address
+        let config = make_config("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa");
+        let (size, sigops) = config.calculate_coinbase_output_constraints();
+        assert_eq!(size, 34);
+        assert_eq!(sigops, 4);
+
+        // P2SH address
+        let config = make_config("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy");
+        let (size, sigops) = config.calculate_coinbase_output_constraints();
+        assert_eq!(size, 32);
+        assert_eq!(sigops, 0);
+
+        // P2WPKH address
+        let config = make_config("bc1qryhgpmfv03qjhhp2dj8nw8g4ewg08jzmgy3cyx");
+        let (size, sigops) = config.calculate_coinbase_output_constraints();
+        assert_eq!(size, 31);
+        assert_eq!(sigops, 0);
+
+        // Taproot address
+        let config = make_config("bc1p2m7q0yn78rjqh200dz0kut5xcxdnfxk4wcsau7zydnrv9ns875eq37vmkz");
+        let (size, sigops) = config.calculate_coinbase_output_constraints();
+        assert_eq!(size, 43);
+        assert_eq!(sigops, 0);
+    }
+>>>>>>> Stashed changes
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -41,34 +41,39 @@ pub fn load_config() -> PleblotteryConfig {
     let mining_server_available_addr = get_available_address();
     let web_server_available_addr = get_available_address();
 
-    PleblotteryConfig {
-        mining_server_config: PlebLotteryMiningServerConfig {
-            listening_port: mining_server_available_addr.port(),
-            pub_key: "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
-                .parse()
-                .expect("Invalid public key"),
-            priv_key: "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
-                .parse()
-                .expect("Invalid private key"),
-            cert_validity: 3600,
-            inactivity_limit: 3600,
-            coinbase_output_script: Address::from_str(
-                "bcrt1q2nfxmhd4n3c8834pj72xagvyr9gl57n5r94fsl",
-            )
+    let mining_server_config = PlebLotteryMiningServerConfig {
+        listening_port: mining_server_available_addr.port(),
+        pub_key: "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+            .parse()
+            .expect("Invalid public key"),
+        priv_key: "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
+            .parse()
+            .expect("Invalid private key"),
+        cert_validity: 3600,
+        inactivity_limit: 3600,
+        coinbase_output_script: Address::from_str("bcrt1q2nfxmhd4n3c8834pj72xagvyr9gl57n5r94fsl")
             .unwrap()
             .assume_checked()
             .script_pubkey(),
-            coinbase_tag: "pleblottery".to_string(),
-            share_batch_size: 10,
-            expected_shares_per_minute: 1.0,
-        },
-        template_distribution_config: PlebLotteryTemplateDistributionClientConfig {
-            server_addr: "127.0.0.1:8442".parse().expect("Invalid server address"),
-            auth_pk: None,
-        },
-        web_config: PlebLotteryWebConfig {
-            listening_port: web_server_available_addr.port(),
-        },
+        coinbase_tag: "pleblottery".to_string(),
+        share_batch_size: 10,
+        expected_shares_per_minute: 1.0,
+    };
+
+    let template_distribution_config = PlebLotteryTemplateDistributionClientConfig {
+        server_addr: "127.0.0.1:8442".parse().expect("Invalid server address"),
+        auth_pk: None,
+        mining_server_config: Some(mining_server_config.clone()),
+    };
+
+    let web_config = PlebLotteryWebConfig {
+        listening_port: web_server_available_addr.port(),
+    };
+
+    PleblotteryConfig {
+        mining_server_config,
+        template_distribution_config,
+        web_config,
     }
 }
 

--- a/tests/test_load_config_from_disk.rs
+++ b/tests/test_load_config_from_disk.rs
@@ -29,3 +29,25 @@ fn test_good_config() {
 fn test_bad_address() {
     let _ = PleblotteryConfig::from_file(config_path("bad_address.toml")).unwrap();
 }
+
+#[test]
+fn test_config_parsing_and_coinbase_output_constraint() {
+    let config = PleblotteryConfig::from_file("tests/test_data/good_config.toml")
+        .expect("Failed to parse config");
+
+    assert!(
+        config
+            .template_distribution_config
+            .mining_server_config
+            .is_some(),
+        "Mining server config should be present in the template distribution config"
+    );
+
+    assert_eq!(
+        config
+            .mining_server_config
+            .calculate_coinbase_output_constraints(),
+        (31, 0),
+        "Coinbase output constraints should match the expected values"
+    );
+}


### PR DESCRIPTION
closes #24 

* `PlebLotteryTemplateDistributionClientConfig` now includes a cloned instance of `PlebLotteryMiningServerConfig` to perform coinbase constraint message calculations.
* Calculations use **total_sigops_cost** counts from the `bitcoin` crate.
* Added tests to cover the updated logic.
* Reorganized `config.rs` to group related operations together for better structure and readability.