### PR TITLE
handle double client removal by logging instead of panicking

### DIFF
--- a/src/sv2_handlers/mining_server_handler.rs
+++ b/src/sv2_handlers/mining_server_handler.rs
@@ -307,7 +307,16 @@ impl Sv2MiningServerHandler for PlebLotteryMiningServerHandler {
         let hashrate = {
             let mut hash = 0.0;
             let clients_guard = self.clients.read().await;
-            let client = clients_guard.get(&client_id).unwrap();
+            let client = match clients_guard.get(&client_id) {
+                Some(c) => c,
+                None => {
+                    info!(
+                        "Client {} not found in clients list — assuming already dropped.",
+                        client_id
+                    );
+                    return;
+                }
+            };
             let client_guard = client.read().await;
 
             // Calculate hashrate from standard channels


### PR DESCRIPTION
closes #32 

Previously, `remove_client` would panic if called twice for the same client_id,
because the second call would unwrap a `None` when looking up the client.

Logs show that `remove_client` can be triggered twice when the Template
Provider disconnects, likely due to `sv2-services` invoking it from multiple
paths.
Now if the client is not found, log  ("Client X not found — assuming already dropped") instead
of panicking.
